### PR TITLE
Ratings shown in  posts and comments

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,8 +11,10 @@ class PostsController < ApplicationController
       @posts = case sort
                when 'views'
                  @course.posts.order(view: :desc).with_rich_text_content_and_embeds
-               when 'ratings'
+               when 'likes'
                  @course.posts.all.left_joins(:ratings).group(:id).order('SUM(ratings.up) DESC')
+               when 'dislikes'
+                 @course.posts.all.left_joins(:ratings).group(:id).order('SUM(ratings.down) DESC')
                else
                  @course.posts.all.left_joins(:comments).group(:id).order('COUNT(comments.id) DESC')
                end
@@ -27,8 +29,10 @@ class PostsController < ApplicationController
       @posts = case sort
                when 'views'
                  Post.order(view: :desc).with_rich_text_content_and_embeds
-               when 'ratings'
+               when 'likes'
                  Post.all.left_joins(:ratings).group(:id).order('SUM(ratings.up) DESC')
+               when 'dislikes'
+                 Post.all.left_joins(:ratings).group(:id).order('SUM(ratings.down) DESC')
                else
                  Post.all.left_joins(:comments).group(:id).order('COUNT(comments.id) DESC')
                end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -77,6 +77,24 @@ class PostsController < ApplicationController
     count
   end
   helper_method :comments_count
+  def sort_comments(commentable)
+    if !params[:sort].nil?
+      sort = params[:sort]
+      @comments = case sort
+                  when 'likes'
+                    commentable.comments.all.left_joins(:ratings).group(:id).order('SUM(ratings.up) DESC')
+                  when 'dislikes'
+                    commentable.comments.all.left_joins(:ratings).group(:id).order('SUM(ratings.down) DESC')
+                  when 'newest'
+                    commentable.comments.all.all.order('created_at DESC')
+                  else
+                    commentable.comments.all
+                  end
+    else
+      @comments = commentable.comments.all
+    end
+  end
+  helper_method :sort_comments
 
   private
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,7 +12,7 @@ class PostsController < ApplicationController
                when 'views'
                  @course.posts.order(view: :desc).with_rich_text_content_and_embeds
                when 'ratings'
-                 @course.posts.all.with_rich_text_content_and_embeds.order('ratings_count DESC')
+                 @course.posts.all.left_joins(:ratings).group(:id).order('SUM(ratings.up) DESC')
                else
                  @course.posts.all.left_joins(:comments).group(:id).order('COUNT(comments.id) DESC')
                end
@@ -28,7 +28,7 @@ class PostsController < ApplicationController
                when 'views'
                  Post.order(view: :desc).with_rich_text_content_and_embeds
                when 'ratings'
-                 Post.all.with_rich_text_content_and_embeds.order('ratings_count DESC')
+                 Post.all.left_joins(:ratings).group(:id).order('SUM(ratings.up) DESC')
                else
                  Post.all.left_joins(:comments).group(:id).order('COUNT(comments.id) DESC')
                end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,7 +2,7 @@
 
 class Comment < ApplicationRecord
   validates :text_body, length: { minimum: 5 }, allow_nil: false, presence: true
-  has_many :ratings
+  has_many :ratings, as: :rateable
   belongs_to :commentable, polymorphic: true
   has_many :comments, as: :commentable
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,7 +4,7 @@ class Post < ApplicationRecord
   belongs_to :course
   has_and_belongs_to_many :tags
   has_many :comments, as: :commentable
-  has_many :ratings
+  has_many :ratings, as: :rateable
   has_rich_text :content
   validates :title, length: { minimum: 1 }, presence: true
   validates :description, length: { minimum: 1 }, presence: true

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -3,6 +3,5 @@
 class Rating < ApplicationRecord
   validates :up, comparison: { greater_than_or_equal_to: 0 }, allow_nil: false
   validates :down, comparison: { greater_than_or_equal_to: 0 }, allow_nil: false
-  belongs_to :post, counter_cache: true
-  belongs_to :comment, counter_cache: true
+  belongs_to :rateable, polymorphic: true
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -12,16 +12,7 @@
           User name <span class="small">~ <%= local_time comment.created_at %> </span>
         </p>
         <div class="d-flex">
-            <% srand(comment.id) %>
-            <% @comment_rating = %w[like dislike none][rand(0..2)] %>
-            <a role="button"
-               class="<%= @comment_rating == 'like' ? 'link-success':'link-muted' %> like me-3">
-              <i class="fas fa-thumbs-up me-1"></i> <%= rand(100) %>
-            </a>
-            <a role="button"
-               class="<%= @comment_rating == 'dislike' ? 'link-danger':'link-muted' %> dislike me-3">
-              <i class="fas fa-thumbs-down me-1"></i> <%= rand(100) %>
-            </a>
+            <%= render 'comments/rating', rating:comment.ratings.first %>
             <a data-mdb-toggle="collapse" href="#replyForm-<%= comment.id %>"><i class="fas fa-reply fa-xs"></i><span class="small"> reply</span></a>
         </div>
       </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -12,7 +12,7 @@
           User name <span class="small">~ <%= local_time comment.created_at %> </span>
         </p>
         <div class="d-flex">
-            <%= render 'comments/rating', rating:comment.ratings.first %>
+            <%= render 'comments/rating', ratings:comment.ratings %>
             <a data-mdb-toggle="collapse" href="#replyForm-<%= comment.id %>"><i class="fas fa-reply fa-xs"></i><span class="small"> reply</span></a>
         </div>
       </div>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -3,9 +3,25 @@
     <div class="col-md-12">
       <div class="card">
         <div class="card-body p-4">
+          <div class="dropdown">
+            <button class="btn btn-outline-primary">Sort Comments
+              <i class="fa-solid fa-filter ms-2"></i>
+            </button>
+            <div class="dropdown-content">
+              <%=link_to "Most Liked", course_post_path(:sort=>"likes")%>
+              <%=link_to "Most Disliked", course_post_path(:sort => "dislikes")%>
+              <%=link_to "Newest", course_post_path(:sort => "newest")%>
+              <%=link_to "Oldest", course_post_path(:sort => "oldest")%>
+            </div>
+          </div>
+          <% if !params[:sort].nil? %>
+            <a href="<%= course_post_path %>" class="btn btn-outline-danger">Clear sorting
+              <i class="fa-solid fa-circle-xmark ms-2"></i>
+            </a>
+          <% end %>
           <div class="row">
             <div class="col">
-              <%= render partial: "comments/comment", collection: @post.comments %>
+              <%= render partial: "comments/comment", collection: sort_comments(@post) %>
             </div>
           </div>
         </div>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -14,11 +14,11 @@
               <%=link_to "Oldest", course_post_path(:sort => "oldest")%>
             </div>
           </div>
-          <% if !params[:sort].nil? %>
-            <a href="<%= course_post_path %>" class="btn btn-outline-danger">Clear sorting
-              <i class="fa-solid fa-circle-xmark ms-2"></i>
-            </a>
-          <% end %>
+          <% unless params[:sort].nil? %>
+          <a href="<%=  course_post_path  %>" class="btn btn-outline-danger">Clear sorting
+            <i class="fa-solid fa-circle-xmark ms-2"></i>
+          </a>
+          <%  end %>
           <div class="row">
             <div class="col">
               <%= render partial: "comments/comment", collection: sort_comments(@post) %>

--- a/app/views/comments/_rating.html.erb
+++ b/app/views/comments/_rating.html.erb
@@ -1,5 +1,5 @@
-<% @num_likes = local_assigns[:rating].nil? ? 0 : local_assigns[:rating].up %>
-<% @num_dislikes = local_assigns[:rating].nil? ? 0 : local_assigns[:rating].down %>
+<% @num_likes = local_assigns[:ratings].count.positive? ? local_assigns[:ratings].sum(:up):0 %>
+<% @num_dislikes = local_assigns[:ratings].count.positive? ? local_assigns[:ratings].sum(:down):0 %>
 
 <!--Random number to decide if the user has liked or disliked the comment-->
 <!--TODO: Replace this with the user's rating later on-->

--- a/app/views/comments/_rating.html.erb
+++ b/app/views/comments/_rating.html.erb
@@ -1,7 +1,7 @@
 <% @num_likes = local_assigns[:rating].nil? ? 0 : local_assigns[:rating].up %>
 <% @num_dislikes = local_assigns[:rating].nil? ? 0 : local_assigns[:rating].down %>
 
-<!--Random number to decide if the user has liked or disliked the post-->
+<!--Random number to decide if the user has liked or disliked the comment-->
 <!--TODO: Replace this with the user's rating later on-->
 <% @comment_rating = %w[like dislike none][rand(0..2)] %>
 

--- a/app/views/comments/_rating.html.erb
+++ b/app/views/comments/_rating.html.erb
@@ -1,0 +1,15 @@
+<% @num_likes = local_assigns[:rating].nil? ? 0 : local_assigns[:rating].up %>
+<% @num_dislikes = local_assigns[:rating].nil? ? 0 : local_assigns[:rating].down %>
+
+<!--Random number to decide if the user has liked or disliked the post-->
+<!--TODO: Replace this with the user's rating later on-->
+<% @comment_rating = %w[like dislike none][rand(0..2)] %>
+
+<a role="button"
+   class="<%= @comment_rating == 'like' ? 'link-success':'link-muted' %> like me-3">
+  <i class="fas fa-thumbs-up me-1"></i> <%= @num_likes %>
+</a>
+<a role="button"
+   class="<%= @comment_rating == 'dislike' ? 'link-danger':'link-muted' %> dislike me-3">
+  <i class="fas fa-thumbs-down me-1"></i> <%= @num_dislikes %>
+</a>

--- a/app/views/layouts/_clear_sort.html.erb
+++ b/app/views/layouts/_clear_sort.html.erb
@@ -1,0 +1,7 @@
+<% unless local_assigns[:sort].nil? %>
+  <div class="mx-2">
+    <a href="<%=  local_assigns[:path]  %>" class="btn btn-outline-danger">Clear sorting
+      <i class="fa-solid fa-circle-xmark ms-2"></i>
+    </a>
+  </div>
+<%  end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,46 @@
+<div class="header-partial">
+  <nav class="navbar bg-light">
+    <div class="container-fluid">
+      <div class="d-flex">
+        <h1 class="navbar-brand">
+          <%=link_to "GateExchange", courses_path%>
+        </h1>
+        <div class="navbar-nav me-auto mb-2 mb-lg-0">
+          <div class="d-flex">
+            <% if @course.nil? %>
+              <%  if current_page?(posts_path) %>
+                <div class="dropdown">
+                  <button class="btn btn-outline-success">Filter Posts</button>
+                  <div class="dropdown-content">
+                    <%= link_to "Comments", posts_path(:sort => "comments") %>
+                    <%= link_to "Most Liked", posts_path(:sort => "likes") %>
+                    <%= link_to "Most Disliked", posts_path(:sort => "dislikes") %>
+                    <%= link_to "Most Viewed", posts_path(:sort => "views") %>
+                  </div>
+                </div>
+                <%= render "layouts/clear_sort", sort:params[:sort], path:posts_path %>
+              <% end %>
+            <% else %>
+              <%  if current_page?(course_posts_path(@course.id)) %>
+                <div class="dropdown">
+                  <button class="btn btn-outline-success">Filter Posts</button>
+                  <div class="dropdown-content">
+                    <%= link_to "Comments", course_posts_path(@course.id, :sort => "comments") %>
+                    <%= link_to "Most Liked", course_posts_path(@course.id, :sort => "likes") %>
+                    <%= link_to "Most Disliked", course_posts_path(@course.id, :sort => "dislikes") %>
+                    <%= link_to "Most Viewed", course_posts_path(@course.id,  :sort => "views") %>
+                  </div>
+                </div>
+                <%= render "layouts/clear_sort", sort:params[:sort], path:course_posts_path(@course.id) %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+      <form role="search" class="d-flex">
+        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
+        <button class="btn btn-outline-success" type="submit">Search</button>
+      </form>
+    </div>
+  </nav>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,8 @@
               <button class="btn btn-outline-success">Filter Posts</button>
               <div class="dropdown-content">
                 <%=link_to "Comments", course_posts_path(@course.id, :sort => "comments")%>
-                <%=link_to "Highest Rated", course_posts_path(@course.id, :sort => "ratings")%>
+                <%=link_to "Most Liked", course_posts_path(@course.id, :sort => "likes")%>
+                <%=link_to "Most Disliked", course_posts_path(@course.id, :sort => "dislikes")%>
                 <%=link_to "Most Viewed", course_posts_path(@course.id,  :sort => "views")%>
               </div>
               </div>
@@ -56,7 +57,8 @@
               <button class="btn btn-outline-success">Filter Posts</button>
               <div class="dropdown-content">
                 <%=link_to "Comments", posts_path(:sort => "comments")%>
-                <%=link_to "Highest Rated", posts_path(:sort => "ratings")%>
+                <%=link_to "Most Liked", posts_path(:sort => "likes")%>
+                <%=link_to "Most Disliked", posts_path(:sort => "dislikes")%>
                 <%=link_to "Most Viewed", posts_path(:sort => "views")%>
               </div>
               </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,47 +30,8 @@
   </head>
 
   <body>
-  <div class="header-partial">
-    <nav class="navbar bg-light">
-      <div class="container-fluid">
-        <h1 class="navbar-brand">
-          <%=link_to "GateExchange", courses_path%>
-        </h1>
-        <% if @course != nil %>
-          <% if current_page?(course_posts_path(@course.id))%>
-            <div class = "navbar-nav me-auto mb-2 mb-lg-0">
-              <div class="dropdown">
-              <button class="btn btn-outline-success">Filter Posts</button>
-              <div class="dropdown-content">
-                <%=link_to "Comments", course_posts_path(@course.id, :sort => "comments")%>
-                <%=link_to "Most Liked", course_posts_path(@course.id, :sort => "likes")%>
-                <%=link_to "Most Disliked", course_posts_path(@course.id, :sort => "dislikes")%>
-                <%=link_to "Most Viewed", course_posts_path(@course.id,  :sort => "views")%>
-              </div>
-              </div>
-          </div>
-          <% end %>
-        <% end %>
-        <% if current_page?(posts_path)%>
-            <div class = "navbar-nav me-auto mb-2 mb-lg-0">
-              <div class="dropdown">
-              <button class="btn btn-outline-success">Filter Posts</button>
-              <div class="dropdown-content">
-                <%=link_to "Comments", posts_path(:sort => "comments")%>
-                <%=link_to "Most Liked", posts_path(:sort => "likes")%>
-                <%=link_to "Most Disliked", posts_path(:sort => "dislikes")%>
-                <%=link_to "Most Viewed", posts_path(:sort => "views")%>
-              </div>
-              </div>
-          </div>
-        <% end %>
-        <form role="search" class="d-flex">
-          <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-          <button class="btn btn-outline-success" type="submit">Search</button>
-        </form>
-      </div>
-    </nav>
-  </div>
+
+  <%= render "layouts/header" %>
 
   <% if flash[:notice] or flash[:warning] %>
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -36,7 +36,7 @@
               <a href="<%= course_post_path(post.course.id, post.id) %>" class="btn btn-success">View details</a>
               <button class="btn btn-warning disabled"><%= post.view %> views &nbsp; <i class="fa fa-eye"></i> </button>
               <button class="btn btn-primary disabled"><%= post.comments.count %> comments &nbsp; <i class="fa-solid fa-message"></i> </button>
-              <%= render 'posts/rating', rating:post.ratings.first %>
+              <%= render 'posts/rating', ratings:post.ratings %>
             </div>
           </div>
         </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -36,6 +36,7 @@
               <a href="<%= course_post_path(post.course.id, post.id) %>" class="btn btn-success">View details</a>
               <button class="btn btn-warning disabled"><%= post.view %> views &nbsp; <i class="fa fa-eye"></i> </button>
               <button class="btn btn-primary disabled"><%= post.comments.count %> comments &nbsp; <i class="fa-solid fa-message"></i> </button>
+              <%= render 'posts/rating', rating:post.ratings.first %>
             </div>
           </div>
         </div>

--- a/app/views/posts/_rating.html.erb
+++ b/app/views/posts/_rating.html.erb
@@ -1,5 +1,5 @@
-<% @num_likes = local_assigns[:rating].nil? ? 0 : local_assigns[:rating].up %>
-<% @num_dislikes = local_assigns[:rating].nil? ? 0 : local_assigns[:rating].down %>
+<% @num_likes = local_assigns[:ratings].count.positive? ? local_assigns[:ratings].sum(:up): 0  %>
+<% @num_dislikes = local_assigns[:ratings].count.positive? ? local_assigns[:ratings].sum(:down) : 0 %>
 
 <!--Random number to decide if the user has liked or disliked the post-->
 <!--TODO: Replace this with the user's rating later on-->

--- a/app/views/posts/_rating.html.erb
+++ b/app/views/posts/_rating.html.erb
@@ -1,0 +1,15 @@
+<% @num_likes = local_assigns[:rating].nil? ? 0 : local_assigns[:rating].up %>
+<% @num_dislikes = local_assigns[:rating].nil? ? 0 : local_assigns[:rating].down %>
+
+<!--Random number to decide if the user has liked or disliked the post-->
+<!--TODO: Replace this with the user's rating later on-->
+<% @comment_rating = %w[like dislike none][rand(0..2)] %>
+
+<a role="button"
+   class="<%= @comment_rating == 'like' ? 'link-success':'link-muted' %> like mx-3">
+  <i class="fa-2x fas fa-thumbs-up me-1"></i> <%= @num_likes %>
+</a>
+<a role="button"
+   class="<%= @comment_rating == 'dislike' ? 'link-danger':'link-muted' %> dislike mx-3">
+  <i class="fa-2x fas fa-thumbs-down me-1"></i> <%= @num_dislikes %>
+</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,9 @@ Rails.application.routes.draw do
 
   resources :courses do
     resources :posts do
+      resources :ratings
       resources :comments do
+        resources :ratings
         resources :comments
       end
     end

--- a/db/migrate/20221030211336_create_ratings.rb
+++ b/db/migrate/20221030211336_create_ratings.rb
@@ -5,8 +5,9 @@ class CreateRatings < ActiveRecord::Migration[7.0]
     create_table :ratings do |t|
       t.integer :up
       t.integer :down
-
+      t.references :rateable, polymorphic: true
       t.timestamps
     end
+
   end
 end

--- a/db/migrate/20221201031230_add_rattings_count_to_posts.rb
+++ b/db/migrate/20221201031230_add_rattings_count_to_posts.rb
@@ -1,5 +1,0 @@
-class AddRattingsCountToPosts < ActiveRecord::Migration[7.0]
-  def change
-    add_column :posts, :ratings_count, :integer
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_01_031230) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_21_073745) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -82,7 +82,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_01_031230) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "course_id"
-    t.integer "ratings_count"
     t.index ["course_id"], name: "index_posts_on_course_id"
   end
 
@@ -96,12 +95,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_01_031230) do
   create_table "ratings", force: :cascade do |t|
     t.integer "up"
     t.integer "down"
+    t.string "rateable_type"
+    t.integer "rateable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "post_id"
     t.integer "comment_id"
     t.index ["comment_id"], name: "index_ratings_on_comment_id"
     t.index ["post_id"], name: "index_ratings_on_post_id"
+    t.index ["rateable_type", "rateable_id"], name: "index_ratings_on_rateable"
   end
 
   create_table "tags", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -375,15 +375,23 @@ Course.all.each { |course| course.posts.create!(posts.shuffle.slice(0, rand(1..5
   Comment.all.sample.comments.create!(comments.shuffle.slice(0, rand(1..10)))
 end
 
+def upvote(rateable)
+  rateable.ratings.create!(up:1,down:0)
+end
+
+def downvote(rateable)
+  rateable.ratings.create!(up:0,down:1)
+end
+
 def rate_collection(collection)
   collection.each do |item|
-    chance = rand(1..4)
-    if chance == 1
-      item.ratings.create!(up:rand(50..100), down:rand(1..50))
-    elsif chance == 2
-      item.ratings.create!(up:rand(1..50), down:rand(50..100))
-    elsif chance == 3
-      item.ratings.create!(up:rand(1..100), down:rand(1..100))
+    (1..10).each do ||
+      chance = rand(1..3)
+      if chance == 1
+        upvote(item)
+      elsif chance == 2
+        downvote(item)
+      end
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -374,3 +374,19 @@ Course.all.each { |course| course.posts.create!(posts.shuffle.slice(0, rand(1..5
   Post.all.sample.comments.create!(comments.shuffle.slice(0, rand(1..25)))
   Comment.all.sample.comments.create!(comments.shuffle.slice(0, rand(1..10)))
 end
+
+def rate_collection(collection)
+  collection.each do |item|
+    chance = rand(1..4)
+    if chance == 1
+      item.ratings.create!(up:rand(50..100), down:rand(1..50))
+    elsif chance == 2
+      item.ratings.create!(up:rand(1..50), down:rand(50..100))
+    elsif chance == 3
+      item.ratings.create!(up:rand(1..100), down:rand(1..100))
+    end
+  end
+end
+
+rate_collection(Post.all)
+rate_collection(Comment.all)


### PR DESCRIPTION
### Ratings are now shown in posts and comments

- Both posts and comments can be sorted by the number of up-votes or down-votes
- Posts and comments have a has_many relationship with the ratings
- An up-vote is a rating object like this `{up:1, down:0}`
- - A down-vote is a rating object like this `{up:0, down:1}`
- To show all the upvotes and downvotes I simply add up the number of up and down votes for a particular comment or post
- This same sum is used when sorting

### Screenshots of posts and comments sorted by number of likes

![image](https://user-images.githubusercontent.com/62907095/205727191-e7c9c223-fcaf-4407-81b8-4941dd4c82bd.png)
![image](https://user-images.githubusercontent.com/62907095/205727313-7b2aec02-6695-4644-b3bf-2ff3db31dce4.png)

### What's missing

- Since we do not have user model working yet I randomly color some upvotes as green and some downvotes as red to show that the user has liked or disliked that post. This should be replaced with the user's rating status.
- We still need the ability to add a like, a dislike, or remove a rating from a post/comment
